### PR TITLE
a50: Use libinit for handling variants

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,6 +16,6 @@
 
 LOCAL_PATH := $(call my-dir)
 
-ifneq ($(filter a505f, $(TARGET_DEVICE)),)
+ifneq ($(filter a50, $(TARGET_DEVICE)),)
 include $(call all-subdir-makefiles,$(LOCAL_PATH))
 endif

--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -15,9 +15,9 @@
 #
 
 PRODUCT_MAKEFILES := \
-    $(LOCAL_DIR)/aosp_a505f.mk
+    $(LOCAL_DIR)/aosp_a50.mk
 
 COMMON_LUNCH_CHOICES := \
-    aosp_a505f-eng \
-    aosp_a505f-user \
-    aosp_a505f-userdebug
+    aosp_a50-eng \
+    aosp_a50-user \
+    aosp_a50-userdebug

--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -14,17 +14,20 @@
 # limitations under the License.
 
 ## Inherit from the common tree
-include device/samsung/a50-common/BoardConfigCommon.mk
+include device/samsung/universal9610-common/BoardConfigCommon.mk
 
 ## Inherit from the proprietary configuration
-include vendor/samsung/a505f/BoardConfigVendor.mk
+include vendor/samsung/a50/BoardConfigVendor.mk
 
-DEVICE_PATH := device/samsung/a505f
+DEVICE_PATH := device/samsung/a50
 
-TARGET_OTA_ASSERT_DEVICE := a505f,a50,a50dd
+TARGET_OTA_ASSERT_DEVICE := a50
 
 ## APEX image
 DEXPREOPT_GENERATE_APEX_IMAGE := true
+
+# Init
+TARGET_INIT_VENDOR_LIB := //$(DEVICE_PATH):libinit_a50
 
 ## Manifest
 DEVICE_MANIFEST_FILE += $(DEVICE_PATH)/device_manifest.xml

--- a/aosp.dependencies
+++ b/aosp.dependencies
@@ -1,6 +1,6 @@
 [
     {
-        "repository": "android_device_samsung_a50-common",
-        "target_path": "device/samsung/a50-common"
+        "repository": "android_device_samsung_universal9610-common",
+        "target_path": "device/samsung/universal9610-common"
     }
 ]

--- a/aosp_a50.mk
+++ b/aosp_a50.mk
@@ -19,7 +19,7 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/full_base_telephony.mk)
 
 ## Inherit from a505f device
-$(call inherit-product, device/samsung/a505f/device.mk)
+$(call inherit-product, device/samsung/a50/device.mk)
 
 ## Boot Animation
 TARGET_BOOT_ANIMATION_RES := 1080
@@ -37,19 +37,11 @@ $(call inherit-product, vendor/aosp/config/common_full_phone.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/updatable_apex.mk)
 
 ## Device identifier, this must come after all inclusions
-PRODUCT_DEVICE := a505f
-PRODUCT_NAME := aosp_a505f
+PRODUCT_DEVICE := a50
+PRODUCT_NAME := aosp_a50
 PRODUCT_BRAND := samsung
 PRODUCT_MODEL := SM-A505F
 PRODUCT_MANUFACTURER := samsung
 PRODUCT_SHIPPING_API_LEVEL := 28
 
 PRODUCT_GMS_CLIENTID_BASE := android-samsung
-
-## Use the latest CTS approved build identifiers
-PRODUCT_BUILD_PROP_OVERRIDES += \
-    PRODUCT_DEVICE=a50 \
-    PRODUCT_NAME=a50dd \
-    PRIVATE_BUILD_DESC="a50dd-user 11 RP1A.200720.012 A505FDDS9CUK1 release-keys"
-
-BUILD_FINGERPRINT := samsung/a50dd/a50:11/RP1A.200720.012/A505FDDS9CUK1:user/release-keys

--- a/init/Android.bp
+++ b/init/Android.bp
@@ -1,0 +1,16 @@
+//
+// Copyright (C) 2021 The LineageOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+cc_library_static {
+    name: "libinit_a50",
+    recovery_available: true,
+    shared_libs: ["libbase"],
+    srcs: ["init_a50.cpp"],
+    include_dirs: [
+        "system/core/base/include",
+        "system/core/init"
+    ]
+}

--- a/init/init_a50.cpp
+++ b/init/init_a50.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2021 The LineageOS Project
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
+
+#define _REALLY_INCLUDE_SYS__SYSTEM_PROPERTIES_H_
+#include <sys/_system_properties.h>
+#include <android-base/properties.h>
+#include <android-base/logging.h>
+#include <vector>
+
+#include "property_service.h"
+#include "vendor_init.h"
+
+using android::base::GetProperty;
+using std::string;
+
+std::vector<string> ro_props_default_source_order = {
+    "",
+    "odm.",
+    "product.",
+    "system.",
+    "system_ext.",
+    "vendor.",
+};
+
+void property_override(string prop, string value) {
+    auto pi = (prop_info*) __system_property_find(prop.c_str());
+
+    if (pi != nullptr)
+        __system_property_update(pi, value.c_str(), value.size());
+    else
+        __system_property_add(prop.c_str(), prop.size(), value.c_str(), value.size());
+}
+
+void set_ro_build_prop(const string &prop, const string &value, bool product = true) {
+    string prop_name;
+
+    for (const auto &source : ro_props_default_source_order) {
+        if (product)
+            prop_name = "ro.product." + source + prop;
+        else
+            prop_name = "ro." + source + "build." + prop;
+
+        property_override(prop_name.c_str(), value.c_str());
+    }
+}
+
+void set_build_fingerprint(string device, string name, string build) {
+    string build_fingerprint;
+
+    build_fingerprint = "samsung/" + name + "/" + device + ":11/RP1A.200720.012/" + build + ":user/release-keys";
+    set_ro_build_prop("fingerprint", build_fingerprint, false);
+    property_override("ro.bootimage.build.fingerprint", build_fingerprint);
+
+    set_ro_build_prop("name", name);
+    set_ro_build_prop("name", name, false);
+    set_ro_build_prop("device", device);
+    set_ro_build_prop("device", device, false);
+}
+
+void vendor_load_properties() {
+    string model;
+
+    model = GetProperty("ro.boot.product.model", "");
+    if(model.empty()){
+        model = GetProperty("ro.boot.em.model", "");
+    }
+
+    if (model == "SM-A505F") {
+        set_build_fingerprint("a50", "a50dd", "A505FDDS9CUK1");
+    } else if (model == "SM-A505FN") {
+        set_build_fingerprint("a50", "a50xx", "A505FNXXS9CUJ1");
+    } else if (model == "SM-A505G") {
+        set_build_fingerprint("a50", "a50ub", "A505GUBS9CVA3");
+    } else if (model == "SM-A505GN") {
+        set_build_fingerprint("a50", "a50xtc", "A505GNDXS9CVA1");
+    } else {
+        LOG(ERROR) << __func__ << ": Coudn't indentify model!";
+    }
+
+    set_ro_build_prop("model", model);
+    set_ro_build_prop("product", model, false);
+}


### PR DESCRIPTION
- rebrand to a50 (which is the device codename)

Signed-off-by: eun0115 <gianpaoloestacio5@gmail.com>